### PR TITLE
feat: add delay parameter to override.mock

### DIFF
--- a/docs/src/pages/reference/configuration/full-example.md
+++ b/docs/src/pages/reference/configuration/full-example.md
@@ -40,6 +40,7 @@ module.exports = {
           properties: {
             '/tag|name/': () => faker.name.lastName(),
           },
+          delay: 500
         },
       },
     },

--- a/src/core/generators/msw.ts
+++ b/src/core/generators/msw.ts
@@ -71,7 +71,7 @@ export const generateMSWImports = (
 
 export const generateMSW = async (
   { operationId, response, verb, tags }: GeneratorVerbOptions,
-  { pathRoute, override, context, delay }: GeneratorOptions,
+  { pathRoute, override, context }: GeneratorOptions,
 ) => {
   const { definitions, definition, imports } = await getMockDefinition({
     operationId,
@@ -106,7 +106,7 @@ export const generateMSW = async (
           : '',
       handler: `rest.${verb}('${route}', (_req, res, ctx) => {
         return res(
-          ctx.delay(${delay || 1000}),
+          ctx.delay(${override?.mock?.delay || 1000}),
           ctx.status(200, 'Mocked status'),${
             value && value !== 'undefined'
               ? `\nctx.${responseType}(get${pascal(operationId)}Mock()),`

--- a/src/types/generator.ts
+++ b/src/types/generator.ts
@@ -105,7 +105,6 @@ export type GeneratorOptions = {
   override: NormalizedOverrideOutput;
   context: ContextSpecs;
   mock: boolean;
-  delay?: number;
 };
 
 export type GeneratorClient = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -57,6 +57,7 @@ export type NormalizedOverrideOutput = {
     format?: { [key: string]: unknown };
     required?: boolean;
     baseUrl?: string;
+    delay?: number;
   };
   header: false | ((info: InfoObject) => string[]);
   formData: boolean | NormalizedMutator;


### PR DESCRIPTION
## Status
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
Add a `delay` property to `override.mock` that can be used to set the delay value for all `msw` mocked requests

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_master | [[link](https://github.com/anymaniax/orval/pull/345)]

## Todos
- [ ] Tests
- [x] Documentation
- [ ] Changelog Entry (unreleased)
